### PR TITLE
rewrite to use USB notifiers

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,2 +1,0 @@
-const char *removeFiles[] = {"/home/user/privatekey", "/private/ssnumber.pdf"}; // Files silk-guardian will remove upon detecting change in usb state.
-const char *shredIterations = "3"; // How many times to shred file. The more iterations the longer it takes.

--- a/silk.c
+++ b/silk.c
@@ -1,113 +1,143 @@
-#include <linux/module.h>    // included for all kernel modules
-#include <linux/kernel.h>    // included for KERN_INFO
-#include <linux/init.h>      // included for __init and __exit macros
+#define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
 #include <linux/usb.h>
-#include <linux/usb/hcd.h>
-#include <linux/list.h>
-#include <linux/kthread.h>
-#include <linux/sched.h>
 #include <linux/reboot.h>
-#include <linux/kmsg_dump.h>
-#include <linux/reboot.h>
-#include <linux/suspend.h>
-#include <linux/syscalls.h>
-#include <linux/syscore_ops.h>
-#include <linux/uaccess.h>
-#include "config.h"
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Nate Brune");
 MODULE_DESCRIPTION("A module that protects you from having a very bad no good terrible day.");
 
-uint initialProducts[64];
-uint initialSerials[64];
-uint currentProducts[64];
-uint currentSerials[64];
-uint counter = 0;
-uint bcounter = 0;
-struct usb_device *dev, *childdev = NULL;
-struct usb_bus *bus = NULL;
-int chix = 0;
-bool debugDone = false;
 
+/* Files silk-guardian will remove upon detecting change in usb state. */
+static char *remove_files[] = {
+	"/home/user/privatekey",
+	"/private/ssnumber.pdf",
+	NULL,	/* Must be NULL terminated */
+};
 
-static struct task_struct *thread1;
+/* How many times to shred file. The more iterations the longer it takes. */
+static char *shredIterations = "3";
 
-int guardian(void)
+/* List of all USB devices you want whitelisted (i.e. ignored) */
+static const struct usb_device_id whitelist_table[] = {
+	{ USB_DEVICE(0x0000, 0x0000) },
+	{ },
+};
+
+static void panic_time(void)
 {
 	int i;
-	int j;
 
-	while (!kthread_should_stop()) {
-		if (debugDone) {
-		} else {
-			i = 0;
-			list_for_each_entry(bus, &usb_bus_list, bus_list) {
-				dev = bus->root_hub;
-				usb_hub_for_each_child(dev, chix, childdev) {
-				if (childdev) {
-					currentProducts[bcounter]=childdev->descriptor.idProduct;
-					currentSerials[bcounter]=childdev->descriptor.iSerialNumber;
-					bcounter=bcounter+1;
-				}
-			}
-		}
-		for(; i<=counter; i++) {
-			if (initialProducts[i]!=currentProducts[i] || initialSerials[i]!=currentSerials[i]) {
-				if (debugDone) {
-				} else {
-					printk("Change detected!\n");
-					printk("Removing files... ");
-					for (; j < sizeof(removeFiles) / sizeof(removeFiles[0]); j++) {
-						char *shred_argv[] = { "/usr/bin/shred", "-f", "-u", "-n", shredIterations,  removeFiles[j], NULL };
-						call_usermodehelper(shred_argv[0], shred_argv, NULL, UMH_WAIT_EXEC);
-					}
-					printk("done.\n");
-					printk("Syncing & powering off.\n");
-					printk("Good luck in court!\n");
-					kernel_power_off();
-					debugDone=true;
-					}
-				}
-			}
-		bcounter = 0;
-		}
+	pr_info("shredding...\n");
+	for (i = 0; remove_files[i] != NULL; ++i) {
+		char *shred_argv[] = {
+			"/usr/bin/shred",
+			"-f", "-u", "-n",
+			shredIterations,
+			remove_files[i],
+			NULL,
+		};
+		call_usermodehelper(shred_argv[0], shred_argv,
+				    NULL, UMH_WAIT_EXEC);
+	}
+	printk("...done.\n");
+	printk("Syncing & powering off.\n");
+	kernel_power_off();
+}
+
+/*
+ * returns 0 if no match, 1 if match
+ *
+ * Taken from drivers/usb/core/driver.c, as it's not exported for our use :(
+ */
+static int usb_match_device(struct usb_device *dev,
+			    const struct usb_device_id *id)
+{
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_VENDOR) &&
+	    id->idVendor != le16_to_cpu(dev->descriptor.idVendor))
+		return 0;
+
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_PRODUCT) &&
+	    id->idProduct != le16_to_cpu(dev->descriptor.idProduct))
+		return 0;
+
+	/* No need to test id->bcdDevice_lo != 0, since 0 is never
+	   greater than any unsigned number. */
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_DEV_LO) &&
+	    (id->bcdDevice_lo > le16_to_cpu(dev->descriptor.bcdDevice)))
+		return 0;
+
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_DEV_HI) &&
+	    (id->bcdDevice_hi < le16_to_cpu(dev->descriptor.bcdDevice)))
+		return 0;
+
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_DEV_CLASS) &&
+	    (id->bDeviceClass != dev->descriptor.bDeviceClass))
+		return 0;
+
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_DEV_SUBCLASS) &&
+	    (id->bDeviceSubClass != dev->descriptor.bDeviceSubClass))
+		return 0;
+
+	if ((id->match_flags & USB_DEVICE_ID_MATCH_DEV_PROTOCOL) &&
+	    (id->bDeviceProtocol != dev->descriptor.bDeviceProtocol))
+		return 0;
+
+	return 1;
+}
+
+
+
+static void usb_dev_remove(struct usb_device *dev)
+{
+	const struct usb_device_id *dev_id;
+
+	/* Check our whitelist to see if we want to ignore this device */
+	dev_id = &whitelist_table[0];
+	while (!dev_id) {
+		if (usb_match_device(dev, dev_id))
+			return;
+		dev_id++;
+	}
+
+	/* Not a device we were ignoring, something bad went wrong, panic! */
+	panic_time();
+}
+
+static int notify(struct notifier_block *self, unsigned long action, void *dev)
+{
+	switch (action) {
+	case USB_DEVICE_ADD:
+		/* We added a new device, do we care? */
+		break;
+	case USB_DEVICE_REMOVE:
+		/* A USB device was removed */
+		usb_dev_remove(dev);
+		break;
+	default:
+		break;
 	}
 	return 0;
 }
-static int __init hello_init(void)
-{
-	printk("Silk Guardian Module Loaded\n");
-	printk("Listing Currently Trusted USB Devices\n");
-	printk("-------------------------------------\n");
-	list_for_each_entry(bus, &usb_bus_list, bus_list) {
-		dev = bus->root_hub;
-		//usb_hub_for_each_child macro not supported in 3.2.0, so trying with 3.7.6.
-		usb_hub_for_each_child(dev, chix, childdev) {
-		if (childdev) {
-			initialProducts[counter] = childdev->descriptor.idProduct;
-			initialSerials[counter] = childdev->descriptor.iSerialNumber;
 
-			printk("Vendor Id:%x, Product Id:%x\n",
-			       childdev->descriptor.idVendor,
-			       childdev->descriptor.idProduct);
-			counter = counter + 1;
-			}
-		}
-	}
-	thread1 = kthread_create(guardian,NULL,"thread1");
-	if ((thread1)) {
-		wake_up_process(thread1);
-	}
+static struct notifier_block usb_notify = {
+	.notifier_call = notify,
+};
+
+static int __init silk_init(void)
+{
+	pr_info("Now watching USB devices...\n");
+	usb_register_notify(&usb_notify);
 	return 0;
-
 }
+module_init(silk_init);
 
-static void __exit hello_cleanup(void)
+static void __exit silk_exit(void)
 {
-	kthread_stop(thread1);
-	printk("Guardian stopped successfully!\n");
+	pr_info("No longer watching USB devices.\n");
+	usb_unregister_notify(&usb_notify);
 }
-
-module_init(hello_init);
-module_exit(hello_cleanup);
+module_exit(silk_exit);


### PR DESCRIPTION
We don't want to suck up a whole CPU just to watch all USB devices in the system, so use the built-in USB notifier mechanism.

Note, this is pretty much a total rewrite, feel free to do with it as you like, I know it's vastly different from your original design, but should be a lot cleaner, easier to follow, and has whitelist support built into it.

Have fun!