### PR TITLE
.gitignore: handle all of the kernel module build cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*
+*.cmd
+*.ko
+*.mod.c
+modules.order
+Module.symvers
+*.o
+*.o.*
+*.swp
+.tmp_versions
+tags
+cscope.*
+ncscope.*
+*.patch


### PR DESCRIPTION
Add a valid .gitignore file to ignore the autogenerated stuff.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>